### PR TITLE
Revert "Update runner.py"

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -1,10 +1,11 @@
 import argparse
-import os
+
 import xml_to_rdf_mapper
+from xml_to_rdf_mapper import transform
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='run xml to rdf transformation')
-    parser.add_argument('--source_XML', dest="source_XML",help='path of the folder containing the source XML files')
+    parser.add_argument('--source_XML', dest="source_XML",help='path of the source XML file')
     parser.add_argument('--gen_pol', dest="gen_pol", help='path of the generator policy file')
     parser.add_argument('--x3ml_mapping', dest="x3ml_mapping", help='path of the X3ML mapping file')
     parser.add_argument('--out_path', dest="out_path", help='path of the folder which will contain the output files' )
@@ -17,14 +18,5 @@ if __name__ == "__main__":
     out_path = args.out_path
     path_to_uuid = args.path_to_uuid
 
-    counter = 0
-    for root, dirs, files in os.walk(source_XML):
-
-        for item in files:
-            if item.endswith(('.xml')):
-                whole_input_path = root+"\\"+ item
-                modified_output_path= out_path+"\\file"+str(counter)+"_entry.rdf"
-                xml_to_rdf_mapper.transformAll(whole_input_path, x3ml_mapping, gen_pol, modified_output_path, path_to_uuid)
-                counter+=1
-    
+    xml_to_rdf_mapper.transformAll(source_XML, x3ml_mapping, gen_pol, out_path, path_to_uuid)
     print("done")


### PR DESCRIPTION
Reverts gtadigital/Xml_RDF_mapping#18

 sudo python3 runner.py --source_XML ../../GTARepo/ProfileParser/Profiles/Archival_Object/target_files/Folder0/ --gen_pol ../../GTARepo/mapping/generator_policy/generator-policy.xml --x3ml_mapping ../../GTARepo/mapping/E78_Collection/Mapping2.0/Mapping15.x3ml --out_path ../test.rdf --path_to_uuid ao_system_object_id
Traceback (most recent call last):
  File "runner.py", line 27, in <module>
    xml_to_rdf_mapper.transformAll(whole_input_path, x3ml_mapping, gen_pol, modified_output_path, path_to_uuid)
  File "/Users/matteolorenzini/GTARepo/Xml_RDF_mapping/xml_to_rdf_mapper.py", line 455, in transformAll
    xml_whole= ET.parse(sourceXML)
  File "src/lxml/etree.pyx", line 3521, in lxml.etree.parse
  File "src/lxml/parser.pxi", line 1859, in lxml.etree._parseDocument
  File "src/lxml/parser.pxi", line 1885, in lxml.etree._parseDocumentFromURL
  File "src/lxml/parser.pxi", line 1789, in lxml.etree._parseDocFromFile
  File "src/lxml/parser.pxi", line 1177, in lxml.etree._BaseParser._parseDocFromFile
  File "src/lxml/parser.pxi", line 615, in lxml.etree._ParserContext._handleParseResultDoc
  File "src/lxml/parser.pxi", line 725, in lxml.etree._handleParseResult
  File "src/lxml/parser.pxi", line 652, in lxml.etree._raiseParseError
OSError: Error reading file '../../GTARepo/ProfileParser/Profiles/Archival_Object/target_files/Folder0/\223689-223888@8ef36ec7-a3a5-4d62-acd5-1ee839f35aa5.xml': failed to load external entity "../../GTARepo/ProfileParser/Profiles/Archival_Object/target_files/Folder0/\223689-223888@8ef36ec7-a3a5-4d62-acd5-1ee839f35aa5.xml"